### PR TITLE
Complete the local package creation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,33 @@
 
 This is a Julia package to create a GitHub repository and deploy Julia package templates. If you want to customize it, please use [PkgTemplates.jl](https://juliaci.github.io/PkgTemplates.jl/stable/).
 
+## Quick Start
+
+Start the interactive command-line interface and follow its prompts:
+
+```julia
+import PkgFactory
+
+PkgFactory.LocalUI.CLI()
+```
+
+The interface checks GitHub CLI authentication, lists the personal account and organizations where the authenticated user can create repositories, discovers and lists the available template directories, collects the remaining settings, displays a confirmation, and then creates the package. Repository owners, templates, and visibility are selected by number; `all-in-one` and `public` are the respective defaults. Prompt examples and defaults are combined as `(example: VALUE, default: VALUE)`; the final creation confirmation requires an explicit `y` or `n`. Package name availability is checked immediately after entry. If the selected repository already exists, the interface asks whether to resume its setup; when resume is declined, it lists unused numeric-suffix suggestions and checks the selected replacement again. The initial commit is attributed to the authenticated GitHub account.
+
+The Codecov token is optional; press Enter without entering one to skip creating the `CODECOV_TOKEN` repository secret. To configure coverage uploads before the new repository exists, use the **Global Upload Token** from the selected account or organization's settings in [Codecov](https://app.codecov.io/). Account owner or organization administrator access is required to view or generate it; see the [Codecov token guide](https://docs.codecov.com/docs/codecov-tokens). Set `ENV["CODECOV_TOKEN"]` before starting to avoid entering it interactively.
+
+The same workflow is also available as an API:
+
+```julia
+PkgFactory.LocalAPI.create_package(
+    "OWNER_NAME",
+    "MyPkg.jl",
+    ["AUTHOR_NAME"],
+    "My package description",
+)
+```
+
+The API creates the repository and its initial commit, creates the `gh-pages` branch, and configures `DOCUMENTER_KEY`. Pass the Codecov token as the optional fifth argument to also configure `CODECOV_TOKEN`.
+
 ## Documentation
 
 See https://ohno.github.io/PkgFactory.jl.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,11 @@ CurrentModule = PkgFactory
 ```
 
 ```@autodocs
-Modules = [PkgFactory]
+Modules = [
+    PkgFactory,
+    PkgFactory.LocalAPI,
+    PkgFactory.LocalUI,
+    PkgFactory.Templates,
+    PkgFactory.Verifications,
+]
 ```
-

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -29,6 +29,8 @@ Development REPL (with Revise):
 julia -i -E 'using Revise; import Pkg; Pkg.activate("."); using PkgFactory; PkgFactory.hello()'
 ```
 
+Local API tests replace the command runner and SSH key generator with test doubles. The default test suite must not create repositories, change GitHub authentication, or write repository secrets. End-to-end checks should use a dedicated account and repository and must not run in the default CI workflow.
+
 OAuth Device Flow Sequence Diagram:
 
 ```mermaid

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,14 +21,28 @@ import Pkg; Pkg.add(url="https://github.com/ohno/PkgFactory.jl.git")
 
 ```julia
 import PkgFactory
-PkgFactory.CLI()
+
+PkgFactory.LocalUI.CLI()
 ```
 
-The user interface will be imp
+The interactive interface checks GitHub CLI authentication, lists only repository owners available to the authenticated account, discovers template sets from the `templates/` directory, and presents repository owners, templates, and visibility as numbered choices. `all-in-one` is the default template and `public` is the default visibility. It validates each answer, hides the Codecov token when the terminal supports secure input, and asks for confirmation before creating the repository. Examples and defaults are combined as `(example: VALUE, default: VALUE)`, while the final creation confirmation requires an explicit `y` or `n`. Package name availability is checked immediately after entry. It asks whether to resume only when the selected repository already exists; if resume is declined, it presents unused numeric-suffix suggestions and rechecks the selected replacement. The generated Git commit uses the authenticated GitHub login and ID-based noreply email so GitHub can attribute it to the correct account.
 
-## Acknowledgments
+The Codecov token is optional; leave it blank to skip creating the `CODECOV_TOKEN` repository secret. To configure coverage uploads before the new repository exists, use the **Global Upload Token** from the selected account or organization's settings in [Codecov](https://app.codecov.io/). Viewing or generating the token requires account owner or organization administrator access. See the [Codecov token guide](https://docs.codecov.com/docs/codecov-tokens).
 
-[AGENTS.md](https://github.com/ohno/PkgFactory.jl/blob/main/AGENTS.md) was created with Claude Fable 5 (Claude Code, Pro plan) on July 7, 2026.
+The same workflow is also available as an API:
+
+```julia
+PkgFactory.LocalAPI.create_package(
+    "OWNER_NAME",
+    "MyPkg.jl",
+    ["AUTHOR_NAME"],
+    "My package description",
+)
+```
+
+`create_package` uses the authenticated GitHub CLI session. It creates the repository and its initial commit, creates the `gh-pages` branch, and configures the `DOCUMENTER_KEY` repository secret. Pass a Codecov token as the optional fifth argument to also configure `CODECOV_TOKEN`.
+
+If a previous attempt stopped after creating the repository, call `create_package_with_jll` with `resume = true`. Existing repositories are never overwritten unless their `Project.toml` identifies the expected package.
 
 ## API Reference
 

--- a/src/LocalAPI.jl
+++ b/src/LocalAPI.jl
@@ -5,152 +5,720 @@ module LocalAPI
 
 # Packages
 
+import ..Templates
+import ..Verifications
+import Base64
 import DocStringExtensions
 import Git
+import GitHub
+import JSON3
 import gh_cli_jll
 
 function hello()
-    # return "Hello, LocalAPI.jl!"
-    run(`$(Git.git()) --version`)
     return "Hello, LocalAPI.jl!"
 end
 
 # Functions
 
-function check_status_code()
-    return run(`$(gh_cli_jll.gh()) auth status`)
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.git_executable()
+```
+"""
+function git_executable()
+    return Git.git()
 end
 
-function login()
-    return run(`$(gh_cli_jll.gh()) auth login`)
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.gh_executable()
+```
+"""
+function gh_executable()
+    return gh_cli_jll.gh()
 end
 
-function _run_command(cmd::Cmd; env::Dict{String,String}=Dict{String,String}())
+function _git_path_environment()::Dict{String,String}
+    separator = Sys.iswindows() ? ";" : ":"
+    git_directory = dirname(first(git_executable().exec))
+    path = join([git_directory, get(ENV, "PATH", "")], separator)
+    return Dict("PATH" => path)
+end
+
+function _run_command(
+    cmd::Cmd;
+    env::Dict{String,String} = Dict{String,String}(),
+    input::Union{Nothing,String} = nothing,
+)
     out = IOBuffer()
     err = IOBuffer()
-    process = run(pipeline(ignorestatus(setenv(cmd, env)), stdout=out, stderr=err))
+    command = addenv(cmd, env)
+    process = if isnothing(input)
+        run(pipeline(ignorestatus(command), stdout = out, stderr = err))
+    else
+        run(
+            pipeline(
+                ignorestatus(command),
+                stdin = IOBuffer(input),
+                stdout = out,
+                stderr = err,
+            ),
+        )
+    end
     stdout = String(take!(out))
     stderr = String(take!(err))
     return success(process), stdout, stderr
 end
 
-function _run_command_or_throw(cmd::Cmd; env::Dict{String,String}=Dict{String,String}())
-    ok, stdout, stderr = _run_command(cmd; env=env)
-    ok || error("Command failed: $(cmd)\nSTDOUT:\n$(stdout)\nSTDERR:\n$(stderr)")
+function _redact(text::String, redactions::Vector{String})::String
+    for redaction in redactions
+        isempty(redaction) || (text = replace(text, redaction => "[REDACTED]"))
+    end
+    return text
+end
+
+function _run_command_or_throw(
+    cmd::Cmd;
+    env::Dict{String,String} = Dict{String,String}(),
+    input::Union{Nothing,String} = nothing,
+    redactions::Vector{String} = String[],
+    command_runner = _run_command,
+)
+    ok, stdout, stderr = command_runner(cmd; env = env, input = input)
+    if !ok
+        stdout = _redact(stdout, redactions)
+        stderr = _redact(stderr, redactions)
+        error("Command failed: $(cmd)\nSTDOUT:\n$(stdout)\nSTDERR:\n$(stderr)")
+    end
     return stdout
 end
 
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.check_status_code()
+```
 """
-function create_package_with_jll(
-    access_token::String,
+function check_status_code(; command_runner = _run_command)::Bool
+    ok, _, _ = command_runner(
+        `$(gh_executable()) auth status`;
+        env = Dict{String,String}(),
+        input = nothing,
+    )
+    return ok
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.login()
+```
+"""
+function login()::Bool
+    process = run(ignorestatus(`$(gh_executable()) auth login`))
+    return success(process)
+end
+
+const RepositoryOwner = NamedTuple{(:login, :name, :kind),Tuple{String,String,Symbol}}
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Return the authenticated GitHub user's commit identity.
+
+```
+PkgFactory.LocalAPI.get_authenticated_user()
+```
+"""
+function get_authenticated_user(; command_runner = _run_command)
+    response = _run_command_or_throw(
+        `$(gh_executable()) api user`;
+        command_runner = command_runner,
+    )
+    user = JSON3.read(response)
+    login = String(user.login)
+    user_id = Int(user.id)
+    return (login = login, email = "$(user_id)+$(login)@users.noreply.github.com")
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Return the authenticated personal account and organizations where it can create repositories.
+
+```
+PkgFactory.LocalAPI.get_repository_owners()
+```
+"""
+function get_repository_owners(; command_runner = _run_command)::Vector{RepositoryOwner}
+    query = """
+    query(\$endCursor: String) {
+      viewer {
+        login
+        name
+        organizations(first: 100, after: \$endCursor) {
+          nodes {
+            login
+            name
+            viewerCanCreateRepositories
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    """
+    response = _run_command_or_throw(
+        `$(gh_executable()) api graphql --paginate --slurp -f query=$(query)`;
+        command_runner = command_runner,
+    )
+    pages = JSON3.read(response)
+    isempty(pages) && error("GitHub did not return an authenticated user.")
+
+    viewer = first(pages).data.viewer
+    login = String(viewer.login)
+    name = isnothing(viewer.name) ? login : String(viewer.name)
+    owners = RepositoryOwner[(login = login, name = name, kind = :user)]
+
+    organizations = RepositoryOwner[]
+    for page in pages
+        for organization in page.data.viewer.organizations.nodes
+            organization.viewerCanCreateRepositories || continue
+            organization_login = String(organization.login)
+            organization_name =
+                isnothing(organization.name) ? organization_login :
+                String(organization.name)
+            push!(
+                organizations,
+                (
+                    login = organization_login,
+                    name = organization_name,
+                    kind = :organization,
+                ),
+            )
+        end
+    end
+    sort!(organizations; by = owner -> lowercase(owner.login))
+    append!(owners, organizations)
+    return owners
+end
+
+function _normalize_repo_name(repo_name::String)::String
+    repo_name = strip(repo_name)
+    return endswith(repo_name, ".jl") ? repo_name : "$(repo_name).jl"
+end
+
+function _get_package_name(repo_name::String)::String
+    return replace(_normalize_repo_name(repo_name), r"\.jl$" => "")
+end
+
+function _verify_inputs(
     owner_name::String,
     repo_name::String,
     author_names::Vector{String},
-    package_description::String;
-    commit_message::String = "Using PkgFactory.jl",
+    visibility::String,
 )
-    gh_env = Dict("GH_TOKEN" => access_token)
+    check_owner = Verifications.verify_owner_name(owner_name)
+    check_owner == "OK" || error("Owner name is not valid: $(check_owner)")
 
-    # create repository
-    _run_command_or_throw(`$(gh_cli_jll.gh()) repo create $(owner_name)/$(repo_name) --public --description $(package_description) --homepage https://$(owner_name).github.io/$(repo_name) --confirm`; env=gh_env)
+    package_name = _get_package_name(repo_name)
+    check_package = Verifications.verify_package_name(package_name)
+    check_package == "OK" || error("Package name is not valid: $(check_package)")
 
-    # set up deploy key and secret
-    pubkey, privkey = GitHub.genkeys()
-    _run_command_or_throw(`$(gh_cli_jll.gh()) api repos/$(owner_name)/$(repo_name)/keys --method POST -f title=Documenter -f key=$(pubkey) -F read_only=false`; env=gh_env)
-    _run_command_or_throw(`$(gh_cli_jll.gh()) secret set DEPLOY_KEY --repo $(owner_name)/$(repo_name) --body $(privkey)`; env=gh_env)
+    isempty(author_names) && error("Author names must not be empty.")
+    any(isempty(strip(author_name)) for author_name in author_names) &&
+        error("Author names must not contain an empty name.")
+    visibility in ["public", "private"] ||
+        error("Visibility must be either \"public\" or \"private\".")
 
-    # create gh-pages branch for documentation
-    main_ref = strip(_run_command_or_throw(`$(gh_cli_jll.gh()) api repos/$(owner_name)/$(repo_name)/git/ref/heads/main --jq .object.sha`; env=gh_env))
-    _run_command_or_throw(`$(gh_cli_jll.gh()) api repos/$(owner_name)/$(repo_name)/git/refs --method POST -f ref=refs/heads/gh-pages -f sha=$(main_ref)`; env=gh_env)
+    return _normalize_repo_name(repo_name)
+end
 
-    # generate template files and commit them
-    paths_and_contents = generate_template_dict(owner_name, repo_name, author_names, package_description)
-    tempdir = mktempdir()
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
 
-    # set up git repository in temporary directory
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) init`)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) checkout -b main`)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) config user.name $(first(author_names))`)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) config user.email pkgfactory@example.com`)
+```
+PkgFactory.LocalAPI.check_repo("ohno", "MyPkg.jl")
+```
+"""
+function check_repo(
+    owner_name::String,
+    repo_name::String;
+    command_runner = _run_command,
+)::Bool
+    repo_name = _normalize_repo_name(repo_name)
+    cmd = `$(gh_executable()) api repos/$(owner_name)/$(repo_name) --silent`
+    ok, stdout, stderr = command_runner(cmd; env = Dict{String,String}(), input = nothing)
+    ok && return true
+    occursin("404", stderr) && return false
+    error("Command failed: $(cmd)\nSTDOUT:\n$(stdout)\nSTDERR:\n$(stderr)")
+end
 
-    # write template files to temporary directory
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+List repository names visible to the authenticated GitHub CLI account for an owner.
+
+```
+repository_names = PkgFactory.LocalAPI.get_repository_names("ohno")
+```
+"""
+function get_repository_names(
+    owner_name::String;
+    command_runner = _run_command,
+)::Vector{String}
+    jq = ".[].name"
+    response = _run_command_or_throw(
+        `$(gh_executable()) repo list $(owner_name) --limit 1000 --json name --jq $(jq)`;
+        command_runner = command_runner,
+    )
+    return filter(!isempty, strip.(split(response, '\n')))
+end
+
+function _get_project_file(
+    owner_name::String,
+    repo_name::String;
+    command_runner = _run_command,
+)
+    repo_name = _normalize_repo_name(repo_name)
+    cmd = `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/contents/Project.toml --jq .content`
+    ok, stdout, stderr = command_runner(cmd; env = Dict{String,String}(), input = nothing)
+    if ok
+        encoded = replace(stdout, r"\s" => "")
+        return String(Base64.base64decode(encoded))
+    elseif occursin("404", stderr)
+        return nothing
+    end
+    error("Command failed: $(cmd)\nSTDOUT:\n$(stdout)\nSTDERR:\n$(stderr)")
+end
+
+function _write_template_files(tempdir::String, paths_and_contents::Dict{String,String})
     for (path, content) in paths_and_contents
-        file_path = joinpath(tempdir, path)
+        file_path = joinpath(tempdir, split(path, "/")...)
         mkpath(dirname(file_path))
-        write(file_path, content)
+        Templates.write_file(file_path, content)
+    end
+    return true
+end
+
+function _create_local_commit(
+    tempdir::String,
+    git_user_name::String,
+    git_user_email::String,
+    commit_message::String;
+    command_runner = _run_command,
+)
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) init`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) checkout -b main`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) config user.name $(git_user_name)`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) config user.email $(git_user_email)`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) add .`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(tempdir) commit -m $(commit_message)`;
+        command_runner = command_runner,
+    )
+    return true
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.create_repo("ohno", "MyPkg.jl", "My special package")
+```
+"""
+function create_repo(
+    owner_name::String,
+    repo_name::String,
+    package_description::String;
+    visibility::String = "public",
+    command_runner = _run_command,
+)
+    repo_name = _normalize_repo_name(repo_name)
+    visibility_option = visibility == "private" ? "--private" : "--public"
+    homepage = "https://$(owner_name).github.io/$(repo_name)"
+    _run_command_or_throw(
+        `$(gh_executable()) repo create $(owner_name)/$(repo_name) $(visibility_option) --description $(package_description) --homepage $(homepage)`;
+        command_runner = command_runner,
+    )
+    return true
+end
+
+function _push_initial_commit(
+    owner_name::String,
+    repo_name::String,
+    source_path::String;
+    command_runner = _run_command,
+)
+    repo_name = _normalize_repo_name(repo_name)
+    _run_command_or_throw(
+        `$(gh_executable()) auth setup-git`;
+        env = _git_path_environment(),
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(source_path) remote add origin https://github.com/$(owner_name)/$(repo_name).git`;
+        command_runner = command_runner,
+    )
+    _run_command_or_throw(
+        `$(git_executable()) -C $(source_path) push -u origin main`;
+        command_runner = command_runner,
+    )
+    return true
+end
+
+function _create_initial_commit(
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+    package_description::String,
+    template_name::String,
+    commit_message::String;
+    visibility::String = "public",
+    repository_exists::Bool = false,
+    command_runner = _run_command,
+)
+    paths_and_contents = Templates.generate_template_files_dict(
+        owner_name,
+        repo_name,
+        author_names,
+        package_description,
+        template_name,
+    )
+    git_user = get_authenticated_user(; command_runner = command_runner)
+
+    mktempdir() do tempdir
+        _write_template_files(tempdir, paths_and_contents)
+        _create_local_commit(
+            tempdir,
+            git_user.login,
+            git_user.email,
+            commit_message;
+            command_runner = command_runner,
+        )
+        if !repository_exists
+            create_repo(
+                owner_name,
+                repo_name,
+                package_description,
+                visibility = visibility,
+                command_runner = command_runner,
+            )
+        end
+        _push_initial_commit(
+            owner_name,
+            repo_name,
+            tempdir;
+            command_runner = command_runner,
+        )
+    end
+    return true
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.create_branch_gh_pages("ohno", "MyPkg.jl")
+```
+"""
+function create_branch_gh_pages(
+    owner_name::String,
+    repo_name::String;
+    command_runner = _run_command,
+)::Bool
+    repo_name = _normalize_repo_name(repo_name)
+    branch_cmd = `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/git/ref/heads/gh-pages --silent`
+    branch_exists, _, _ =
+        command_runner(branch_cmd; env = Dict{String,String}(), input = nothing)
+    branch_exists && return true
+
+    main_ref = strip(
+        _run_command_or_throw(
+            `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/git/ref/heads/main --jq .object.sha`;
+            command_runner = command_runner,
+        ),
+    )
+    _run_command_or_throw(
+        `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/git/refs --method POST -f ref=refs/heads/gh-pages -f sha=$(main_ref)`;
+        command_runner = command_runner,
+    )
+    return true
+end
+
+function _repository_secret_exists(
+    owner_name::String,
+    repo_name::String,
+    secret_name::String;
+    command_runner = _run_command,
+)::Bool
+    repo_name = _normalize_repo_name(repo_name)
+    jq = ".[].name"
+    cmd = `$(gh_executable()) secret list --repo $(owner_name)/$(repo_name) --json name --jq $(jq)`
+    ok, stdout, _ = command_runner(cmd; env = Dict{String,String}(), input = nothing)
+    return ok && secret_name in split(stdout)
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.set_repository_secret(
+    "ohno",
+    "MyPkg.jl",
+    "CODECOV_TOKEN",
+    "secret",
+)
+```
+"""
+function set_repository_secret(
+    owner_name::String,
+    repo_name::String,
+    secret_name::String,
+    secret_value::AbstractString;
+    command_runner = _run_command,
+)
+    repo_name = _normalize_repo_name(repo_name)
+    secret_value = String(secret_value)
+    isempty(secret_value) && error("The repository secret must not be empty.")
+    _run_command_or_throw(
+        `$(gh_executable()) secret set $(secret_name) --repo $(owner_name)/$(repo_name)`;
+        input = secret_value,
+        redactions = [secret_value],
+        command_runner = command_runner,
+    )
+    return true
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.get_codecov_url("ohno", "MyPkg.jl")
+```
+"""
+function get_codecov_url(owner_name::String, repo_name::String)::String
+    repo_name = _normalize_repo_name(repo_name)
+    return "https://app.codecov.io/gh/$(owner_name)/$(repo_name)/new"
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.set_codecov("ohno", "MyPkg.jl", "secret")
+```
+"""
+function set_codecov(
+    owner_name::String,
+    repo_name::String,
+    codecov_token::AbstractString;
+    command_runner = _run_command,
+)
+    return set_repository_secret(
+        owner_name,
+        repo_name,
+        "CODECOV_TOKEN",
+        codecov_token;
+        command_runner = command_runner,
+    )
+end
+
+function _deploy_key_exists(
+    owner_name::String,
+    repo_name::String;
+    command_runner = _run_command,
+)::Bool
+    repo_name = _normalize_repo_name(repo_name)
+    jq = ".[].title"
+    cmd = `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/keys --paginate --jq $(jq)`
+    ok, stdout, _ = command_runner(cmd; env = Dict{String,String}(), input = nothing)
+    return ok && "Documenter" in split(stdout, '\n'; keepempty = false)
+end
+
+function _generate_keys()
+    return mktempdir() do tempdir
+        cd(tempdir) do
+            GitHub.genkeys()
+        end
+    end
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+PkgFactory.LocalAPI.set_deploy_key("ohno", "MyPkg.jl")
+```
+"""
+function set_deploy_key(
+    owner_name::String,
+    repo_name::String;
+    command_runner = _run_command,
+    key_generator = _generate_keys,
+)
+    repo_name = _normalize_repo_name(repo_name)
+    key_exists = _deploy_key_exists(owner_name, repo_name; command_runner = command_runner)
+    secret_exists = _repository_secret_exists(
+        owner_name,
+        repo_name,
+        "DOCUMENTER_KEY";
+        command_runner = command_runner,
+    )
+    key_exists && secret_exists && return true
+
+    pubkey, privkey = key_generator()
+    _run_command_or_throw(
+        `$(gh_executable()) api repos/$(owner_name)/$(repo_name)/keys --method POST -f title=Documenter -f key=$(pubkey) -F read_only=false`;
+        command_runner = command_runner,
+    )
+    set_repository_secret(
+        owner_name,
+        repo_name,
+        "DOCUMENTER_KEY",
+        privkey;
+        command_runner = command_runner,
+    )
+    return true
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+Create a GitHub repository, commit the generated package, and configure documentation and coverage secrets using the authenticated GitHub CLI session.
+
+```
+PkgFactory.LocalAPI.create_package_with_jll(
+    "ohno",
+    "MyPkg.jl",
+    ["Shuhei Ohno"],
+    "My special package",
+    "codecov-token",
+)
+```
+"""
+function create_package_with_jll(
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+    package_description::String,
+    codecov_token::AbstractString = "";
+    template_name::String = "all-in-one",
+    visibility::String = "public",
+    commit_message::String = "Using PkgFactory.jl",
+    resume::Bool = false,
+    command_runner = _run_command,
+    key_generator = _generate_keys,
+)
+    codecov_token = String(codecov_token)
+    repo_name = _verify_inputs(owner_name, repo_name, author_names, visibility)
+    check_status_code(; command_runner = command_runner) ||
+        error("GitHub CLI is not authenticated. Run PkgFactory.LocalAPI.login() first.")
+
+    repository_exists = check_repo(owner_name, repo_name; command_runner = command_runner)
+    if repository_exists && !resume
+        error(
+            "The repository, \"$(owner_name)/$(repo_name)\" already exists. Set resume=true to continue an interrupted setup.",
+        )
     end
 
-    # commit and push changes to GitHub
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) add .`)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) commit -m $(commit_message)`)
+    project_file =
+        repository_exists ?
+        _get_project_file(owner_name, repo_name; command_runner = command_runner) : nothing
+    if isnothing(project_file)
+        _create_initial_commit(
+            owner_name,
+            repo_name,
+            author_names,
+            package_description,
+            template_name,
+            commit_message;
+            visibility = visibility,
+            repository_exists = repository_exists,
+            command_runner = command_runner,
+        )
+    else
+        package_name = _get_package_name(repo_name)
+        occursin("name = \"$(package_name)\"", project_file) || error(
+            "The existing repository does not contain the expected package, \"$(package_name)\".",
+        )
+        @info "The initial package commit already exists."
+    end
 
-    # push to GitHub using gh CLI with authentication
-    _run_command_or_throw(`$(gh_cli_jll.gh()) auth setup-git`; env=gh_env)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) remote add origin https://github.com/$(owner_name)/$(repo_name).git`)
-    _run_command_or_throw(`$(Git.git()) -C $(tempdir) push -u origin main`)
+    create_branch_gh_pages(owner_name, repo_name; command_runner = command_runner)
+    set_deploy_key(
+        owner_name,
+        repo_name;
+        command_runner = command_runner,
+        key_generator = key_generator,
+    )
+    if isempty(strip(codecov_token))
+        @info "Skipping the CODECOV_TOKEN repository secret."
+    else
+        set_codecov(owner_name, repo_name, codecov_token; command_runner = command_runner)
+    end
 
     return true
 end
 
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
-"""
-function get_codecov_url(owner_name::String, repo_name::String)::String
-    return "https://app.codecov.io/gh/$(owner_name)/$(repo_name)/new"
-end
 
+```
+PkgFactory.LocalAPI.create_package(
+    "ohno",
+    "MyPkg.jl",
+    ["Shuhei Ohno"],
+    "My special package",
+    "codecov-token",
+)
+```
 """
-$(DocStringExtensions.TYPEDSIGNATURES)
-"""
-function set_codecov(access_token::String, owner_name::String, repo_name::String, codecov_token::String)
-    return set_repository_secret(access_token, owner_name, repo_name, "CODECOV_TOKEN", codecov_token)
-end
-
-"""
-$(DocStringExtensions.TYPEDSIGNATURES)
-"""
-function set_deploy_key(access_token::String, owner_name::String, repo_name::String)
-    # https://github.com/JuliaWeb/GitHub.jl?tab=readme-ov-file#ssh-keys
-    pubkey, privkey = GitHub.genkeys()
-    auth = GitHub.authenticate(access_token)
-    repo = GitHub.repo("$(owner_name)/$(repo_name)"; auth = auth)
+function create_package(
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+    package_description::String,
+    codecov_token::AbstractString = "";
+    kwargs...,
+)
     try
-        response1 = GitHub.create_deploykey(
-            repo;
-            auth = auth,
-            params = Dict(
-                "key" => pubkey,
-                "title" => "Documenter",
-                "read_only" => false,
-                "handle_error" => false,
-            ),
+        create_package_with_jll(
+            owner_name,
+            repo_name,
+            author_names,
+            package_description,
+            codecov_token;
+            kwargs...,
         )
-        response2 = PkgFactory.set_repository_secret(access_token, owner_name, repo_name, "DEPLOY_KEY", privkey)
-        if !isnothing(response1.id) && response2
-            return true
-        else
-            return false
-        end
+        repo_name = _normalize_repo_name(repo_name)
+        return "Success: $(repo_name) is created"
     catch e
-        return false
+        return "Error: $(sprint(showerror, e))"
     end
-end
-
-function create_package(owner_name::String, repo_name::String, author_names::Vector{String}, package_description::String, codecov_token::String)
-    check_name = PkgFactory.verify_package_name(repo_name)
-    if check_name != "OK"
-        return "Error: Package name is not valid: $(check_name)"
-    end
-    PkgFactory.create_repo(PERSONAL_ACCESS_TOKEN, owner_name, repo_name, package_description)
-    PkgFactory.set_deploy_key(PERSONAL_ACCESS_TOKEN, owner_name, repo_name)
-    PkgFactory.get_codecov_url(owner_name, repo_name)
-    PkgFactory.set_codecov(PERSONAL_ACCESS_TOKEN, owner_name, repo_name, codecov_token)    
-    PkgFactory.create_branch_gh_pages(PERSONAL_ACCESS_TOKEN, owner_name, repo_name)
-    paths_and_contents = PkgFactory.generate_template_dict(owner_name, repo_name, author_names, package_description)
-    PkgFactory.commit_files_on_github(PERSONAL_ACCESS_TOKEN, owner_name, repo_name, "main", "Using PkgFactory.jl", paths_and_contents)
-    return "Success: $(repo_name) is created"
 end
 
 end

--- a/src/LocalUI.jl
+++ b/src/LocalUI.jl
@@ -1,13 +1,458 @@
 """
-This module contains the CLI on a REPL.
+This module contains the interactive command-line interface for the local environment.
 """
 module LocalUI
 
+# Packages
+
+import ..LocalAPI
+import ..Templates
+import ..Verifications
+import DocStringExtensions
+
+function hello()
+    return "Hello, LocalUI.jl!"
+end
+
+# Functions
+
+function _read_line(
+    input::IO,
+    output::IO,
+    message::String;
+    default::Union{Nothing,String} = nothing,
+    example::Union{Nothing,String} = nothing,
+)
+    annotations = String[]
+    !isnothing(example) && push!(annotations, "example: $(example)")
+    !isnothing(default) && push!(annotations, "default: $(default)")
+    annotation = isempty(annotations) ? "" : " ($(join(annotations, ", ")))"
+    suffix = "$(annotation): "
+    print(output, message, suffix)
+    flush(output)
+    eof(input) && error("Input ended while waiting for: $(message)")
+    value = String(strip(readline(input)))
+    return isempty(value) && !isnothing(default) ? default : value
+end
+
+function _prompt_value(
+    input::IO,
+    output::IO,
+    message::String;
+    default::Union{Nothing,String} = nothing,
+    example::Union{Nothing,String} = nothing,
+    validator = value -> isempty(value) ? "This value must not be empty." : "OK",
+)
+    while true
+        value = _read_line(input, output, message; default = default, example = example)
+        validation = validator(value)
+        validation == "OK" && return value
+        println(output, "Invalid input: $(validation)")
+    end
+end
+
+function _prompt_yes_no(
+    input::IO,
+    output::IO,
+    message::String;
+    default::Union{Nothing,Bool} = nothing,
+    example::String = "y",
+)::Bool
+    annotations = ["example: $(example)"]
+    !isnothing(default) && push!(annotations, "default: $(default ? "y" : "n")")
+    suffix = " ($(join(annotations, ", "))) (y/n): "
+    while true
+        print(output, message, suffix)
+        flush(output)
+        eof(input) && error("Input ended while waiting for: $(message)")
+        answer = lowercase(strip(readline(input)))
+        isempty(answer) && !isnothing(default) && return default
+        answer in ["y", "yes"] && return true
+        answer in ["n", "no"] && return false
+        println(output, "Please answer y or n.")
+    end
+end
+
+function _read_secret(input::IO, output::IO, message::String)::String
+    if input isa Base.TTY && input === stdin
+        secret = read(Base.getpass(input, output, message), String)
+        println(output)
+        return strip(secret)
+    end
+    return _read_line(input, output, message)
+end
+
+function _prompt_secret(
+    input::IO,
+    output::IO,
+    message::String;
+    example::Union{Nothing,String} = nothing,
+    required::Bool = true,
+    secret_reader = _read_secret,
+)::String
+    annotations = String[]
+    !required && push!(annotations, "optional")
+    !isnothing(example) && push!(annotations, "example: $(example)")
+    annotation = isempty(annotations) ? "" : " ($(join(annotations, ", ")))"
+    prompt = "$(message)$(annotation)"
+    while true
+        secret = secret_reader(input, output, prompt)
+        (!required || !isempty(secret)) && return secret
+        println(output, "Invalid input: This value must not be empty.")
+    end
+end
+
+function _parse_author_names(value::String)::Vector{String}
+    return filter(name -> !isempty(name), strip.(split(value, ',')))
+end
+
+function _suggest_package_names(
+    repo_name::String,
+    repository_names::Vector{String};
+    count::Int = 3,
+)::Vector{String}
+    count > 0 || return String[]
+    package_name = LocalAPI._get_package_name(repo_name)
+    numbered_name = match(r"^(.*?)(\d+)$", package_name)
+    base_name = isnothing(numbered_name) ? package_name : String(numbered_name.captures[1])
+    existing_names = Set(lowercase.(repository_names))
+    suffix_pattern = Regex("^$(base_name)(\\d+)\\.jl\$", "i")
+    existing_suffixes = BigInt[]
+    for repository_name in repository_names
+        suffix_match = match(suffix_pattern, repository_name)
+        isnothing(suffix_match) ||
+            push!(existing_suffixes, parse(BigInt, suffix_match.captures[1]))
+    end
+    requested_suffix =
+        isnothing(numbered_name) ? big(0) : parse(BigInt, numbered_name.captures[2])
+    largest_suffix = isempty(existing_suffixes) ? big(0) : maximum(existing_suffixes)
+    suffix = max(requested_suffix, largest_suffix) + 1
+    suggestions = String[]
+
+    while length(suggestions) < count
+        suggestion = "$(base_name)$(suffix)"
+        lowercase("$(suggestion).jl") in existing_names || push!(suggestions, suggestion)
+        suffix += 1
+    end
+    return suggestions
+end
+
+function _prompt_suggested_package_name(
+    input::IO,
+    output::IO,
+    suggestions::Vector{String},
+)::String
+    isempty(suggestions) && error("No package name suggestions are available.")
+    println(output, "Available package name suggestions:")
+    for (index, suggestion) in enumerate(suggestions)
+        default_label = index == 1 ? " (default)" : ""
+        println(output, "  $(index). $(suggestion)$(default_label)")
+    end
+
+    while true
+        selection = _read_line(
+            input,
+            output,
+            "Select a suggestion or enter another package name";
+            default = "1",
+            example = "2",
+        )
+        index = tryparse(Int, selection)
+        if !isnothing(index)
+            index in eachindex(suggestions) &&
+                return LocalAPI._normalize_repo_name(suggestions[index])
+            println(output, "Invalid input: Select one of the listed suggestions.")
+            continue
+        end
+
+        package_name = LocalAPI._get_package_name(selection)
+        validation = Verifications.verify_package_name(package_name)
+        validation == "OK" && return LocalAPI._normalize_repo_name(selection)
+        println(output, "Invalid input: $(validation)")
+    end
+end
+
+function _prompt_package_name(
+    input::IO,
+    output::IO,
+    owner_name::String;
+    repository_checker,
+    repository_names_provider,
+)
+    repo_name = _prompt_value(
+        input,
+        output,
+        "Package name";
+        example = "MyPkg",
+        validator = value ->
+            Verifications.verify_package_name(LocalAPI._get_package_name(value)),
+    )
+    repo_name = LocalAPI._normalize_repo_name(repo_name)
+    known_repository_names = String[]
+
+    while repository_checker(owner_name, repo_name)
+        println(output, "Repository $(owner_name)/$(repo_name) already exists.")
+        _prompt_yes_no(input, output, "Resume its setup?"; default = false) &&
+            return (repo_name = repo_name, resume = true)
+
+        append!(known_repository_names, repository_names_provider(owner_name))
+        push!(known_repository_names, repo_name)
+        suggestions = _suggest_package_names(repo_name, unique(known_repository_names))
+        repo_name = _prompt_suggested_package_name(input, output, suggestions)
+    end
+
+    return (repo_name = repo_name, resume = false)
+end
+
+function _prompt_template(input::IO, output::IO, template_names::Vector{String})::String
+    isempty(template_names) && error("No package templates are available.")
+    ordered_template_names = copy(template_names)
+    default_index = findfirst(==("all-in-one"), ordered_template_names)
+    if !isnothing(default_index)
+        default_template = popat!(ordered_template_names, default_index)
+        pushfirst!(ordered_template_names, default_template)
+    end
+
+    println(output, "Package templates available:")
+    for (index, template_name) in enumerate(ordered_template_names)
+        default_label = index == 1 ? " (default)" : ""
+        println(output, "  $(index). $(template_name)$(default_label)")
+    end
+
+    while true
+        selection =
+            _read_line(input, output, "Select template"; default = "1", example = "1")
+        index = tryparse(Int, selection)
+        !isnothing(index) &&
+            index in eachindex(ordered_template_names) &&
+            return ordered_template_names[index]
+
+        matching_index = findfirst(==(selection), ordered_template_names)
+        !isnothing(matching_index) && return ordered_template_names[matching_index]
+        println(output, "Invalid input: Select one of the listed package templates.")
+    end
+end
+
+function _prompt_visibility(input::IO, output::IO)::String
+    visibilities = ["public", "private"]
+    println(output, "Repository visibility:")
+    for (index, visibility) in enumerate(visibilities)
+        default_label = index == 1 ? " (default)" : ""
+        println(output, "  $(index). $(visibility)$(default_label)")
+    end
+
+    while true
+        selection =
+            _read_line(input, output, "Select visibility"; default = "1", example = "2")
+        index = tryparse(Int, selection)
+        !isnothing(index) && index in eachindex(visibilities) && return visibilities[index]
+
+        matching_index = findfirst(==(lowercase(selection)), visibilities)
+        !isnothing(matching_index) && return visibilities[matching_index]
+        println(output, "Invalid input: Select one of the listed visibility options.")
+    end
+end
+
+function _prompt_repository_owner(input::IO, output::IO, owners)::String
+    isempty(owners) && error("No GitHub account can create a repository.")
+    println(output, "Repository owners available to the authenticated account:")
+    for (index, owner) in enumerate(owners)
+        kind = owner.kind == :user ? "personal account" : "organization"
+        println(output, "  $(index). @$(owner.login) — $(owner.name) ($(kind))")
+    end
+
+    while true
+        selection = _read_line(
+            input,
+            output,
+            "Select repository owner";
+            default = "1",
+            example = "1",
+        )
+        index = tryparse(Int, selection)
+        !isnothing(index) && index in eachindex(owners) && return owners[index].login
+
+        matching_index =
+            findfirst(owner -> lowercase(owner.login) == lowercase(selection), owners)
+        !isnothing(matching_index) && return owners[matching_index].login
+        println(output, "Invalid input: Select one of the listed repository owners.")
+    end
+end
+
+function _print_summary(
+    output::IO,
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+    package_description::String,
+    template_name::String,
+    visibility::String,
+    commit_message::String,
+    resume::Bool,
+    codecov_configured::Bool,
+)
+    println(output, "\nPackage configuration")
+    println(output, "  Repository:  $(owner_name)/$(repo_name)")
+    println(output, "  Authors:     $(join(author_names, ", "))")
+    println(output, "  Description: $(package_description)")
+    println(output, "  Template:    $(template_name)")
+    println(output, "  Visibility:  $(visibility)")
+    println(output, "  Commit:      $(commit_message)")
+    println(output, "  Resume:      $(resume ? "yes" : "no")")
+    println(output, "  Codecov:     $(codecov_configured ? "configured" : "skipped")")
+    return nothing
+end
+
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
+
+Start an interactive command-line workflow that collects package settings and delegates repository creation to [`PkgFactory.LocalAPI.create_package_with_jll`](@ref).
+
+```
+PkgFactory.LocalUI.CLI()
+```
 """
-function CLI()
-    println("Creating package...")
+function CLI(;
+    input::IO = stdin,
+    output::IO = stdout,
+    environment::AbstractDict = ENV,
+    status_checker = LocalAPI.check_status_code,
+    login_handler = LocalAPI.login,
+    package_creator = LocalAPI.create_package_with_jll,
+    repository_checker = LocalAPI.check_repo,
+    repository_names_provider = LocalAPI.get_repository_names,
+    repository_owners_provider = LocalAPI.get_repository_owners,
+    templates_provider = Templates.list_templates,
+    secret_reader = _read_secret,
+)::Bool
+    println(output, "PkgFactory local package setup")
+    println(output, "Follow the prompts to create a Julia package repository.\n")
+
+    if !status_checker()
+        println(output, "GitHub CLI is not authenticated.")
+        _prompt_yes_no(input, output, "Log in to GitHub now?"; default = true) || begin
+            println(output, "Cancelled: GitHub authentication is required.")
+            return false
+        end
+        login_handler() || begin
+            println(output, "GitHub authentication failed.")
+            return false
+        end
+    end
+
+    owners = try
+        repository_owners_provider()
+    catch e
+        println(output, "Failed to load repository owners: $(sprint(showerror, e))")
+        return false
+    end
+    owner_name = _prompt_repository_owner(input, output, owners)
+    package_selection = try
+        _prompt_package_name(
+            input,
+            output,
+            owner_name;
+            repository_checker = repository_checker,
+            repository_names_provider = repository_names_provider,
+        )
+    catch e
+        println(output, "Failed to check package name availability: $(sprint(showerror, e))")
+        return false
+    end
+    repo_name = package_selection.repo_name
+    resume = package_selection.resume
+
+    author_text = _prompt_value(
+        input,
+        output,
+        "Authors (comma-separated; written to LICENSE)";
+        example = "Alice Smith, Bob Jones",
+        validator = value ->
+            isempty(_parse_author_names(value)) ? "At least one author is required." : "OK",
+    )
+    author_names = _parse_author_names(author_text)
+
+    package_description = _prompt_value(
+        input,
+        output,
+        "Package description";
+        example = "Tools for data analysis",
+    )
+    template_names = try
+        templates_provider()
+    catch e
+        println(output, "Failed to load package templates: $(sprint(showerror, e))")
+        return false
+    end
+    template_name = _prompt_template(input, output, template_names)
+    visibility = _prompt_visibility(input, output)
+    commit_message = _prompt_value(
+        input,
+        output,
+        "Initial commit message";
+        default = "Using PkgFactory.jl",
+    )
+    codecov_token = String(strip(string(get(environment, "CODECOV_TOKEN", ""))))
+    if isempty(codecov_token)
+        println(output, "\nHow to get a Codecov upload token:")
+        println(output, "  1. Sign in at https://app.codecov.io/.")
+        println(
+            output,
+            "  2. Open $(owner_name) Settings > Global Upload Token and copy the token.",
+        )
+        println(output, "     Account owner or organization administrator access is required.")
+        println(output, "  Guide: https://docs.codecov.com/docs/codecov-tokens")
+        codecov_token = _prompt_secret(
+            input,
+            output,
+            "Codecov token";
+            example = "01234567-89ab-cdef-0123-456789abcdef",
+            required = false,
+            secret_reader = secret_reader,
+        )
+        codecov_token = String(strip(codecov_token))
+    else
+        println(output, "Using the Codecov token from CODECOV_TOKEN.")
+    end
+
+    _print_summary(
+        output,
+        owner_name,
+        repo_name,
+        author_names,
+        package_description,
+        template_name,
+        visibility,
+        commit_message,
+        resume,
+        !isempty(codecov_token),
+    )
+    _prompt_yes_no(input, output, "Create this repository?") || begin
+        println(output, "Cancelled: no repository was created.")
+        return false
+    end
+
+    println(output, "\nCreating $(owner_name)/$(repo_name)...")
+    try
+        created = package_creator(
+            owner_name,
+            repo_name,
+            author_names,
+            package_description,
+            codecov_token;
+            template_name = template_name,
+            visibility = visibility,
+            commit_message = commit_message,
+            resume = resume,
+        )
+        created || error("The local API did not complete the package setup.")
+    catch e
+        println(output, "Failed: $(sprint(showerror, e))")
+        return false
+    end
+
+    println(output, "Created: https://github.com/$(owner_name)/$(repo_name)")
+    return true
 end
 
 end

--- a/src/PkgFactory.jl
+++ b/src/PkgFactory.jl
@@ -7,7 +7,7 @@ end
 include("Verifications.jl")
 include("Templates.jl")
 include("LocalAPI.jl")
-# include("LocalUI.jl")
+include("LocalUI.jl")
 # include("WebAPI.jl")
 # include("WebUI.jl")
 

--- a/src/Templates.jl
+++ b/src/Templates.jl
@@ -1,5 +1,5 @@
 """
-This module contains functions for generating the package from [templates](../template) directory using [Mustache.jl](https://github.com/jverzani/Mustache.jl).
+This module contains functions for generating the package from the [templates](https://github.com/ohno/PkgFactory.jl/tree/main/templates) directory using [Mustache.jl](https://github.com/jverzani/Mustache.jl).
 """
 module Templates
 
@@ -17,6 +17,10 @@ end
 
 # Functions
 
+function _get_templates_path()::String
+    return normpath(joinpath(@__DIR__, "..", "templates"))
+end
+
 """
 $(DocStringExtensions.TYPEDSIGNATURES)
 
@@ -25,7 +29,21 @@ path_dir = PkgFactory.Templates.get_template_path("all-in-one")
 ```
 """
 function get_template_path(template_name::String)
-    return normpath("$(@__DIR__)/../templates/$(template_name)/")
+    return normpath(joinpath(_get_templates_path(), template_name))
+end
+
+"""
+$(DocStringExtensions.TYPEDSIGNATURES)
+
+```
+template_names = PkgFactory.Templates.list_templates()
+```
+"""
+function list_templates()::Vector{String}
+    templates_path = _get_templates_path()
+    return sort(
+        filter(name -> isdir(joinpath(templates_path, name)), readdir(templates_path)),
+    )
 end
 
 """
@@ -37,7 +55,7 @@ path_files = PkgFactory.Templates.list_files(path_dir)
 ```
 """
 function list_files(template_path::String)::Vector{String}
-    return [joinpath(dir, f) for (dir, _, fs) in walkdir(template_path) for f in fs]
+    return sort([joinpath(dir, f) for (dir, _, fs) in walkdir(template_path) for f in fs])
 end
 
 """
@@ -54,11 +72,10 @@ function read_file(path::String)::String
     try
         text = Base.read(path, String)
         @info "Success to read file: $(path)"
-        
         return text
-    catch
-        @info "Failed to read file: $(path)"
-        return ""
+    catch e
+        @error "Failed to read file: $(path)" exception = (e, catch_backtrace())
+        rethrow()
     end
 end
 
@@ -77,9 +94,9 @@ function write_file(path::String, content::String)
         Base.write(path, content)
         @info "write_file: $(path)"
         return true
-    catch
-        @info "Failed to write file: $(path)"
-        return error("Failed to write file: $(path)")
+    catch e
+        @error "Failed to write file: $(path)" exception = (e, catch_backtrace())
+        rethrow()
     end
 end
 
@@ -96,23 +113,30 @@ paths_and_contents = PkgFactory.Templates.generate_template_files_dict(
 )
 ```
 """
-function generate_template_files_dict(owner_name::String, repo_name::String, author_names::Vector{String}, package_description::String, template_name::String)::Dict{String, String}
+function generate_template_files_dict(
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+    package_description::String,
+    template_name::String,
+)::Dict{String,String}
 
+    package_name = replace(repo_name, r"\.jl$" => "")
     ctx = Dict(
-        "PKG"      => replace(repo_name, ".jl" => ""),
-        "REPO"     => repo_name,
-        "OWNER"    => owner_name,
-        "DESCR"    => package_description,
-        "UUID"     => string(UUIDs.uuid4()),
-        "AUTHORS"  => author_names,
+        "PKG" => package_name,
+        "REPO" => repo_name,
+        "OWNER" => owner_name,
+        "DESCR" => package_description,
+        "UUID" => string(UUIDs.uuid4()),
+        "AUTHORS" => author_names,
         "LICENSOR" => join(author_names, ", "),
-        "URL"      => "https://github.com/$(owner_name)/$(repo_name)",
-        "VERSION"  => "v0.0.1",
-        "YEAR"     => Dates.year(Dates.today()),
-        "MONTH"    => lowercase(Dates.monthabbr(Dates.today())),
+        "URL" => "https://github.com/$(owner_name)/$(repo_name)",
+        "VERSION" => "v0.0.1",
+        "YEAR" => Dates.year(Dates.today()),
+        "MONTH" => lowercase(Dates.monthabbr(Dates.today())),
     )
 
-    paths_and_contents = Dict{String, String}()
+    paths_and_contents = Dict{String,String}()
 
     path_dir = get_template_path(template_name)
     path_files = list_files(path_dir)
@@ -125,7 +149,7 @@ function generate_template_files_dict(owner_name::String, repo_name::String, aut
         end
         # content
         text = read_file(path_file)
-        rendered = if key[end-3:end] == ".yml" && key[end-5:end] != "CI.yml"
+        rendered = if endswith(key, ".yml") && !endswith(key, "CI.yml")
             text
         else
             Mustache.render(text, ctx)
@@ -133,7 +157,7 @@ function generate_template_files_dict(owner_name::String, repo_name::String, aut
         # 
         paths_and_contents[key] = rendered
     end
-    
+
     return paths_and_contents
 
 end
@@ -152,7 +176,11 @@ Example:
 PkgFactory.update_template("OWNER_NAME", "template", ["AUTHOR1", "AUTHOR2"])
 ```
 """
-function update_template(owner_name::String, repo_name::String, author_names::Vector{String})::Dict{String, String}
+function update_template(
+    owner_name::String,
+    repo_name::String,
+    author_names::Vector{String},
+)::Dict{String,String}
     template = PkgTemplates.Template(;
         dir = "$(@__DIR__)/../",
         user = owner_name,

--- a/templates/all-in-one/docs/src/developer.md
+++ b/templates/all-in-one/docs/src/developer.md
@@ -2,53 +2,64 @@
 CurrentModule = {{{PKG}}}
 ```
 
-# Developer Guide
+# [Developer Guide](@id developer-guide)
 
 If you are planning significant changes, open an [issue](https://github.com/{{{OWNER}}}/{{{PKG}}}.jl/issues) first. The [ColPrac](https://github.com/SciML/ColPrac) guidelines are recommended. For Julia package development basics, see:
 - [How to develop a Julia package](https://julialang.org/contribute/developing_package/)
 - [Pkg: Creating packages](https://pkgdocs.julialang.org/v1/creating-packages/)
 
-## One-Time Local Setup
+## [One-Time Local Setup](@id local-setup)
 
-This procedure is required only once.
+This procedure is required only once. Install [Git](https://git-scm.com/) and [Julia](https://julialang.org/install/) on your local machine before starting.
 
-1. Clone the [repository](https://github.com/{{{OWNER}}}/{{{PKG}}}.jl).
+1. Fork the [repository](https://github.com/{{{OWNER}}}/{{{PKG}}}.jl) on GitHub.
+2. Clone the forked repository. Replace `xxxxxx` with your GitHub username.
    ```sh
-   git clone https://github.com/{{{OWNER}}}/{{{PKG}}}.jl.git
+   git clone https://github.com/xxxxxx/{{{PKG}}}.jl.git
    cd {{{PKG}}}.jl
    ```
-2. Install development tools: [Revise.jl](https://github.com/timholy/Revise.jl) and [Runic.jl](https://github.com/fredrikekre/Runic.jl).
+3. Install development tools: [Revise.jl](https://github.com/timholy/Revise.jl) and [Runic.jl](https://github.com/fredrikekre/Runic.jl).
    ```sh
    julia --startup-file=no -e 'import Pkg; Pkg.add("Revise")'
    julia --project=@runic --startup-file=no -e 'using Pkg; Pkg.add("Runic")'
    ```
 
-## Daily Development Flow
+## [Daily Development Flow](@id development-flow)
 
 This is the typical workflow for making changes.
 
-1. Start an interactive session with [Revise.jl](https://github.com/timholy/Revise.jl).
+1. Create a branch for your changes. Replace `xxx` with the issue number (e.g. `issue/123`).
    ```sh
    cd {{{PKG}}}.jl
-   julia --startup-file=no -i -E 'using Revise; import Pkg; Pkg.activate("."); using {{{PKG}}}'
+   git switch -c issue/xxx
    ```
-2. Change the source code:
+2. Start an interactive session with [Revise.jl](https://github.com/timholy/Revise.jl).
+   ```sh
+   julia --startup-file=no -i -e 'using Revise; import Pkg; Pkg.activate("."); using {{{PKG}}}'
+   ```
+3. Change the source code:
    - When making new functions or updating docstrings, refer to [Documenter: Adding docstrings](https://documenter.juliadocs.org/stable/man/guide/#Adding-Some-Docstrings).
    - If you need a new dependency, use `julia --project=. --startup-file=no -e 'import Pkg; Pkg.add("SomePackage"); Pkg.resolve(); Pkg.instantiate()'`. Replace `SomePackage` with the actual package name.
-3. Format the source code with [Runic.jl](https://github.com/fredrikekre/Runic.jl).
+4. Format the source code with [Runic.jl](https://github.com/fredrikekre/Runic.jl).
    ```sh
    julia --project=@runic --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- --inplace .
    ```
-4. Run the tests.
+5. Run the tests. It will take a few minutes.
    ```sh
    julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
    ```
-5. Build the documentation locally.
+6. Build the documentation locally. HTML files (`docs/build/*.html`) will be generated. Check them with Chrome or any other web browsers.
    ```sh
    julia --project=docs --startup-file=no -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
    julia --project=docs --startup-file=no -e 'include("docs/make.jl")'
    ```
-6. Submit a pull request (after steps 3–5 succeed).
+7. Commit and push the changes (after steps 4–6 succeed).
+   ```sh
+   git add "path/to/changed/file"
+   git commit -m "commit message"
+   git push origin issue/xxx
+   ```
+8. Submit a pull request on GitHub.
 
 ## Versioning and Registering (for Maintainers)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,101 @@
 using PkgFactory
 using Test
 
+mutable struct FakeCommandRunner
+    commands::Vector{String}
+    environments::Vector{Dict{String,String}}
+    inputs::Vector{Union{Nothing,String}}
+    authenticated::Bool
+    repository_exists::Bool
+    project_file::Union{Nothing,String}
+    gh_pages_exists::Bool
+    deploy_key_exists::Bool
+    documenter_secret_exists::Bool
+end
+
+mutable struct FakePackageCreator
+    calls::Vector{Any}
+    result::Bool
+end
+
+function (creator::FakePackageCreator)(args...; kwargs...)
+    push!(creator.calls, (args = args, options = (; kwargs...)))
+    return creator.result
+end
+
+function FakeCommandRunner(;
+    authenticated::Bool = true,
+    repository_exists::Bool = false,
+    project_file::Union{Nothing,String} = nothing,
+    gh_pages_exists::Bool = false,
+    deploy_key_exists::Bool = false,
+    documenter_secret_exists::Bool = false,
+)
+    return FakeCommandRunner(
+        String[],
+        Dict{String,String}[],
+        Union{Nothing,String}[],
+        authenticated,
+        repository_exists,
+        project_file,
+        gh_pages_exists,
+        deploy_key_exists,
+        documenter_secret_exists,
+    )
+end
+
+function (runner::FakeCommandRunner)(
+    cmd::Cmd;
+    env::Dict{String,String} = Dict{String,String}(),
+    input::Union{Nothing,String} = nothing,
+)
+    command = string(cmd)
+    push!(runner.commands, command)
+    push!(runner.environments, env)
+    push!(runner.inputs, input)
+
+    if occursin("auth status", command)
+        return runner.authenticated, "", runner.authenticated ? "" : "not authenticated"
+    elseif occursin("api graphql", command)
+        return true,
+        """[{"data":{"viewer":{"login":"ohno","name":"Shuhei OHNO","organizations":{"nodes":[{"login":"AllowedOrg","name":"Allowed Org","viewerCanCreateRepositories":true},{"login":"DeniedOrg","name":"Denied Org","viewerCanCreateRepositories":false}]}}}}]""",
+        ""
+    elseif occursin("api user", command)
+        return true, """{"login":"ohno","name":"Shuhei OHNO","id":59360244}""", ""
+    elseif occursin("repo list", command)
+        return true, "MyPkg.jl\nMyPkg1.jl\nMyPkg2.jl\n", ""
+    elseif occursin("api repos/", command) && occursin("--silent", command)
+        return runner.repository_exists,
+        "",
+        runner.repository_exists ? "" : "HTTP 404: Not Found"
+    elseif occursin("contents/Project.toml", command)
+        if isnothing(runner.project_file)
+            return false, "", "HTTP 404: Not Found"
+        end
+        return true, PkgFactory.LocalAPI.Base64.base64encode(runner.project_file), ""
+    elseif occursin("git/ref/heads/gh-pages", command)
+        return runner.gh_pages_exists,
+        "",
+        runner.gh_pages_exists ? "" : "HTTP 404: Not Found"
+    elseif occursin("git/ref/heads/main", command)
+        return true, "abc123\n", ""
+    elseif occursin("secret list", command)
+        secrets = runner.documenter_secret_exists ? "DOCUMENTER_KEY\n" : ""
+        return true, secrets, ""
+    elseif occursin("/keys --paginate", command)
+        keys = runner.deploy_key_exists ? "Documenter\n" : ""
+        return true, keys, ""
+    end
+
+    return true, "", ""
+end
+
 @testset "hello" begin
     @test occursin("Hello", PkgFactory.hello())
     @test occursin("Hello", PkgFactory.Verifications.hello())
     @test occursin("Hello", PkgFactory.Templates.hello())
     @test occursin("Hello", PkgFactory.LocalAPI.hello())
+    @test occursin("Hello", PkgFactory.LocalUI.hello())
 end
 
 @testset "verify_owner_name" begin
@@ -21,7 +111,6 @@ end
     @test "OK" != PkgFactory.Verifications.verify_package_name("algebra")
     @test "OK" != PkgFactory.Verifications.verify_package_name("Linear_algebra")
     @test "OK" != PkgFactory.Verifications.verify_package_name("Math+Physics")
-    @test "OK" != PkgFactory.Verifications.verify_package_name("algebra")
     @test "OK" != PkgFactory.Verifications.verify_package_name("Eigen京")
     @test "OK" != PkgFactory.Verifications.verify_package_name("VMC")
     @test "OK" != PkgFactory.Verifications.verify_package_name("Cake")
@@ -29,13 +118,19 @@ end
     @test "OK" != PkgFactory.Verifications.verify_package_name("Jump")
     @test "OK" != PkgFactory.Verifications.verify_package_name("VMCjl")
     @test "OK" != PkgFactory.Verifications.verify_package_name("VMC.jl")
-    @test "OK" != PkgFactory.Verifications.verify_package_name("Eigen京")
 end
 
 @testset "get_template_path" begin
     path_dir = PkgFactory.Templates.get_template_path("all-in-one")
     @test isdir(path_dir)
-    @test occursin("all-in-one", path_dir)    
+    @test occursin("all-in-one", path_dir)
+end
+
+@testset "list_templates" begin
+    template_names = PkgFactory.Templates.list_templates()
+    @test template_names == sort(template_names)
+    @test "all-in-one" in template_names
+    @test "minimum" in template_names
 end
 
 @testset "list_files" begin
@@ -44,18 +139,18 @@ end
     @test 0 < length(path_files)
     @test 0 < sum(occursin("README.md", path_file) for path_file in path_files)
     @test 0 < sum(occursin("LICENSE", path_file) for path_file in path_files)
-    @test 0 == sum(occursin("aaaaa", path_file) for path_file in path_files)    
+    @test 0 == sum(occursin("aaaaa", path_file) for path_file in path_files)
 end
 
 @testset "read_file" begin
-    path_dir   = PkgFactory.Templates.get_template_path("all-in-one")
+    path_dir = PkgFactory.Templates.get_template_path("all-in-one")
     path_files = PkgFactory.Templates.list_files(path_dir)
-    path_file  = path_files[findfirst(occursin("README.md", path_file) for path_file in path_files)]
+    path_file =
+        path_files[findfirst(occursin("README.md", path_file) for path_file in path_files)]
     text = PkgFactory.Templates.read_file(path_file)
     @test 0 < length(path_file)
-    @test occursin("README.md", path_file)    
+    @test occursin("README.md", path_file)
     @test 0 < length(text)
-    @test occursin(".jl", path_file)    
 end
 
 @testset "generate_template_files_dict" begin
@@ -64,7 +159,13 @@ end
     author_names = ["Shuhei Ohno"]
     package_description = "My special package"
     template_name = "all-in-one"
-    paths_and_contents = PkgFactory.Templates.generate_template_files_dict(owner_name, repo_name, author_names, package_description, template_name)
+    paths_and_contents = PkgFactory.Templates.generate_template_files_dict(
+        owner_name,
+        repo_name,
+        author_names,
+        package_description,
+        template_name,
+    )
     @test 0 < length(paths_and_contents)
     @test 0 < length(paths_and_contents["README.md"])
     @test occursin("MyPkg.jl", paths_and_contents["README.md"])
@@ -157,12 +258,412 @@ end
     )
 end
 
-# @testset "PkgFactory.check_status_code" begin
-#     @test PkgFactory.check_status_code()
-# end
+@testset "local API input normalization" begin
+    @test "MyPkg.jl" == PkgFactory.LocalAPI._normalize_repo_name("MyPkg")
+    @test "MyPkg.jl" == PkgFactory.LocalAPI._normalize_repo_name("MyPkg.jl")
+    @test "MyPkg" == PkgFactory.LocalAPI._get_package_name("MyPkg.jl")
+    @test occursin("MyPkg.jl", PkgFactory.LocalAPI.get_codecov_url("ohno", "MyPkg"))
+end
 
+@testset "local API authentication" begin
+    runner = FakeCommandRunner()
+    @test PkgFactory.LocalAPI.check_status_code(; command_runner = runner)
 
-# @testset "JLL executable paths" begin
-#     @test !isempty(PkgFactory.git_executable())
-#     @test !isempty(PkgFactory.gh_executable())
-# end
+    runner = FakeCommandRunner(; authenticated = false)
+    @test !PkgFactory.LocalAPI.check_status_code(; command_runner = runner)
+end
+
+@testset "GitHub account information" begin
+    runner = FakeCommandRunner()
+    user = PkgFactory.LocalAPI.get_authenticated_user(; command_runner = runner)
+    @test user.login == "ohno"
+    @test user.email == "59360244+ohno@users.noreply.github.com"
+
+    owners = PkgFactory.LocalAPI.get_repository_owners(; command_runner = runner)
+    @test getproperty.(owners, :login) == ["ohno", "AllowedOrg"]
+    @test getproperty.(owners, :kind) == [:user, :organization]
+    @test !any(owner.login == "DeniedOrg" for owner in owners)
+
+    repository_names =
+        PkgFactory.LocalAPI.get_repository_names("ohno"; command_runner = runner)
+    @test repository_names == ["MyPkg.jl", "MyPkg1.jl", "MyPkg2.jl"]
+end
+
+@testset "create_package_with_jll" begin
+    runner = FakeCommandRunner()
+    codecov_token = "codecov-secret"
+    private_key = "documenter-secret"
+
+    result = PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg",
+        ["Shuhei Ohno"],
+        "My special package",
+        codecov_token;
+        command_runner = runner,
+        key_generator = () -> ("ssh-ed25519 public", private_key),
+    )
+
+    @test result
+    @test any(occursin("repo create", command) for command in runner.commands)
+    @test any(occursin("auth setup-git", command) for command in runner.commands)
+    @test any(occursin("remote add origin", command) for command in runner.commands)
+    @test any(occursin("push -u origin main", command) for command in runner.commands)
+    @test any(occursin("config user.name ohno", command) for command in runner.commands)
+    @test any(
+        occursin("config user.email 59360244+ohno@users.noreply.github.com", command) for
+        command in runner.commands
+    )
+    @test any(occursin("git/ref/heads/main", command) for command in runner.commands)
+    @test any(occursin("DOCUMENTER_KEY", command) for command in runner.commands)
+    @test any(occursin("CODECOV_TOKEN", command) for command in runner.commands)
+    @test !any(occursin(codecov_token, command) for command in runner.commands)
+    @test !any(occursin(private_key, command) for command in runner.commands)
+    @test codecov_token in runner.inputs
+    @test private_key in runner.inputs
+
+    setup_git_index =
+        findfirst(occursin("auth setup-git", command) for command in runner.commands)
+    @test !isnothing(setup_git_index)
+    @test occursin(
+        dirname(first(PkgFactory.LocalAPI.git_executable().exec)),
+        runner.environments[setup_git_index]["PATH"],
+    )
+
+    create_index =
+        findfirst(occursin("repo create", command) for command in runner.commands)
+    main_ref_index =
+        findfirst(occursin("git/ref/heads/main", command) for command in runner.commands)
+    @test !isnothing(create_index)
+    @test !isnothing(main_ref_index)
+    @test create_index < main_ref_index
+
+    runner_without_codecov = FakeCommandRunner()
+    @test PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg",
+        ["Shuhei Ohno"],
+        "My special package";
+        command_runner = runner_without_codecov,
+        key_generator = () -> ("ssh-ed25519 public", "documenter-secret"),
+    )
+    @test !any(
+        occursin("CODECOV_TOKEN", command) for command in runner_without_codecov.commands
+    )
+
+    runner_with_substring = FakeCommandRunner()
+    substring_token = strip(" codecov-secret ")
+    @test substring_token isa SubString{String}
+    @test PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg",
+        ["Shuhei Ohno"],
+        "My special package",
+        substring_token;
+        command_runner = runner_with_substring,
+        key_generator = () -> ("ssh-ed25519 public", "documenter-secret"),
+    )
+    @test "codecov-secret" in runner_with_substring.inputs
+end
+
+@testset "resume package creation" begin
+    runner = FakeCommandRunner(
+        repository_exists = true,
+        project_file = "name = \"MyPkg\"\n",
+        gh_pages_exists = true,
+        deploy_key_exists = true,
+        documenter_secret_exists = true,
+    )
+
+    @test PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg.jl",
+        ["Shuhei Ohno"],
+        "My special package",
+        "codecov-secret";
+        resume = true,
+        command_runner = runner,
+        key_generator = () -> error("Keys must not be regenerated"),
+    )
+    @test !any(occursin("repo create", command) for command in runner.commands)
+    @test !any(occursin("git commit", command) for command in runner.commands)
+
+    runner =
+        FakeCommandRunner(repository_exists = true, project_file = "name = \"OtherPkg\"\n")
+    @test_throws ErrorException PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg.jl",
+        ["Shuhei Ohno"],
+        "My special package",
+        "codecov-secret";
+        resume = true,
+        command_runner = runner,
+    )
+end
+
+@testset "local API errors" begin
+    runner = FakeCommandRunner(; authenticated = false)
+    @test_throws ErrorException PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg.jl",
+        ["Shuhei Ohno"],
+        "My special package",
+        "codecov-secret";
+        command_runner = runner,
+    )
+
+    runner = FakeCommandRunner(; repository_exists = true)
+    @test_throws ErrorException PkgFactory.LocalAPI.create_package_with_jll(
+        "ohno",
+        "MyPkg.jl",
+        ["Shuhei Ohno"],
+        "My special package",
+        "codecov-secret";
+        command_runner = runner,
+    )
+
+    secret = "must-not-appear"
+    failing_runner =
+        function (cmd::Cmd; env::Dict{String,String}, input::Union{Nothing,String})
+            return false, secret, "failed with $(secret)"
+        end
+    error_message = try
+        PkgFactory.LocalAPI._run_command_or_throw(
+            `fake command`;
+            input = secret,
+            redactions = [secret],
+            command_runner = failing_runner,
+        )
+        ""
+    catch e
+        sprint(showerror, e)
+    end
+    @test !occursin(secret, error_message)
+    @test occursin("[REDACTED]", error_message)
+end
+
+@testset "JLL executable paths" begin
+    @test !isempty(string(PkgFactory.LocalAPI.git_executable()))
+    @test !isempty(string(PkgFactory.LocalAPI.gh_executable()))
+end
+
+@testset "local UI package name suggestions" begin
+    @test PkgFactory.LocalUI._suggest_package_names(
+        "MyPkg.jl",
+        ["MyPkg.jl", "MyPkg02.jl", "MyPkg63.jl"],
+    ) == ["MyPkg64", "MyPkg65", "MyPkg66"]
+
+    existing_repository_names =
+        vcat(["MyPkg.jl"], ["MyPkg$(suffix).jl" for suffix = 1:64])
+    input = IOBuffer(
+        join(
+            [
+                "1",
+                "MyPkg",
+                "n",
+                "",
+                "Alice Smith",
+                "My package description",
+                "",
+                "",
+                "",
+                "",
+                "y",
+            ],
+            "\n",
+        ) * "\n",
+    )
+    output = IOBuffer()
+    creator = FakePackageCreator(Any[], true)
+
+    @test PkgFactory.LocalUI.CLI(;
+        input = input,
+        output = output,
+        environment = Dict{String,String}(),
+        status_checker = () -> true,
+        package_creator = creator,
+        repository_checker = (owner, repo) -> repo == "MyPkg.jl",
+        repository_names_provider = owner -> existing_repository_names,
+        repository_owners_provider = () ->
+            [(login = "ohno", name = "Shuhei OHNO", kind = :user),],
+        templates_provider = () -> ["minimum", "all-in-one"],
+    )
+
+    text = String(take!(output))
+    @test occursin("Repository ohno/MyPkg.jl already exists.", text)
+    @test occursin("Available package name suggestions:", text)
+    @test occursin("1. MyPkg65 (default)", text)
+    @test occursin("2. MyPkg66", text)
+    @test occursin("3. MyPkg67", text)
+    @test only(creator.calls).args[2] == "MyPkg65.jl"
+    @test !only(creator.calls).options.resume
+end
+
+@testset "interactive local UI" begin
+    input = IOBuffer(
+        join(
+            [
+                "2",
+                "invalid",
+                "MyPkg",
+                "Alice, Bob",
+                "My package description",
+                "2",
+                "2",
+                "",
+                "codecov-secret",
+                "",
+                "y",
+            ],
+            "\n",
+        ) * "\n",
+    )
+    output = IOBuffer()
+    creator = FakePackageCreator(Any[], true)
+    repository_owners = [
+        (login = "ohno", name = "Shuhei OHNO", kind = :user),
+        (login = "qumpoo", name = "QUMPOO", kind = :organization),
+    ]
+
+    @test PkgFactory.LocalUI.CLI(;
+        input = input,
+        output = output,
+        environment = Dict{String,String}(),
+        status_checker = () -> true,
+        package_creator = creator,
+        repository_checker = (owner, repo) -> false,
+        repository_owners_provider = () -> repository_owners,
+        templates_provider = () -> ["all-in-one", "minimum"],
+    )
+
+    text = String(take!(output))
+    @test occursin("Invalid input", text)
+    @test occursin("@ohno", text)
+    @test occursin("@qumpoo", text)
+    @test occursin("qumpoo/MyPkg.jl", text)
+    @test occursin("Created: https://github.com/qumpoo/MyPkg.jl", text)
+    @test !occursin("Resume its setup?", text)
+    @test occursin("Select repository owner (example: 1, default: 1):", text)
+    @test occursin("Package templates available:", text)
+    @test occursin("1. all-in-one (default)", text)
+    @test occursin("2. minimum", text)
+    @test occursin("Select template (example: 1, default: 1):", text)
+    @test occursin("Package name (example: MyPkg):", text)
+    @test occursin(
+        "Authors (comma-separated; written to LICENSE) (example: Alice Smith, Bob Jones):",
+        text,
+    )
+    @test occursin("Package description (example: Tools for data analysis):", text)
+    @test occursin("Repository visibility:", text)
+    @test occursin("1. public (default)", text)
+    @test occursin("2. private", text)
+    @test occursin("Select visibility (example: 2, default: 1):", text)
+    @test occursin("Initial commit message (default: Using PkgFactory.jl):", text)
+    @test occursin(
+        "Codecov token (optional, example: 01234567-89ab-cdef-0123-456789abcdef):",
+        text,
+    )
+    @test occursin("How to get a Codecov upload token:", text)
+    @test occursin("qumpoo Settings > Global Upload Token", text)
+    @test occursin("https://docs.codecov.com/docs/codecov-tokens", text)
+    @test occursin("Please answer y or n.", text)
+    @test length(
+        collect(eachmatch(r"Create this repository\? \(example: y\) \(y/n\):", text)),
+    ) == 2
+    @test occursin("Codecov:     configured", text)
+    @test first(findfirst("Codecov token", text)) <
+          first(findfirst("Package configuration", text)) <
+          first(findfirst("Create this repository?", text))
+    @test !occursin("codecov-secret", text)
+    @test length(creator.calls) == 1
+
+    call = only(creator.calls)
+    @test call.args == (
+        "qumpoo",
+        "MyPkg.jl",
+        ["Alice", "Bob"],
+        "My package description",
+        "codecov-secret",
+    )
+    @test call.options.template_name == "minimum"
+    @test call.options.visibility == "private"
+    @test call.options.commit_message == "Using PkgFactory.jl"
+    @test !call.options.resume
+    @test call.args[5] isa String
+end
+
+@testset "resume existing repository from local UI" begin
+    input = IOBuffer(
+        join(
+            [
+                "1",
+                "MyPkg",
+                "y",
+                "Alice",
+                "My package description",
+                "",
+                "",
+                "",
+                "",
+                "y",
+            ],
+            "\n",
+        ) * "\n",
+    )
+    output = IOBuffer()
+    creator = FakePackageCreator(Any[], true)
+
+    @test PkgFactory.LocalUI.CLI(;
+        input = input,
+        output = output,
+        environment = Dict{String,String}(),
+        status_checker = () -> true,
+        package_creator = creator,
+        repository_checker = (owner, repo) -> true,
+        repository_owners_provider = () ->
+            [(login = "ohno", name = "Shuhei OHNO", kind = :user),],
+        templates_provider = () -> ["minimum", "all-in-one"],
+    )
+
+    text = String(take!(output))
+    @test occursin("Repository ohno/MyPkg.jl already exists.", text)
+    @test occursin("Resume its setup? (example: y, default: n) (y/n):", text)
+    @test occursin("1. all-in-one (default)", text)
+    @test occursin("Codecov:     skipped", text)
+    @test only(creator.calls).args[5] == ""
+    @test only(creator.calls).options.template_name == "all-in-one"
+    @test only(creator.calls).options.resume
+end
+
+@testset "local UI cancellation" begin
+    creator = FakePackageCreator(Any[], true)
+    output = IOBuffer()
+    @test !PkgFactory.LocalUI.CLI(;
+        input = IOBuffer("n\n"),
+        output = output,
+        status_checker = () -> false,
+        login_handler = () -> error("Login must not run"),
+        package_creator = creator,
+    )
+    @test isempty(creator.calls)
+    text = String(take!(output))
+    @test occursin("Log in to GitHub now? (example: y, default: y) (y/n):", text)
+    @test occursin("authentication is required", text)
+
+    input = IOBuffer("1\nMyPkg\nAlice\nMy package description\n\n\n\n\nn\n")
+    output = IOBuffer()
+    @test !PkgFactory.LocalUI.CLI(;
+        input = input,
+        output = output,
+        status_checker = () -> true,
+        package_creator = creator,
+        repository_checker = (owner, repo) -> false,
+        repository_owners_provider = () ->
+            [(login = "ohno", name = "Shuhei OHNO", kind = :user),],
+        templates_provider = () -> ["all-in-one", "minimum"],
+    )
+    @test isempty(creator.calls)
+    text = String(take!(output))
+    @test occursin("Codecov:     skipped", text)
+    @test occursin("no repository was created", text)
+end


### PR DESCRIPTION
## Summary

- Complete the `gh`-based local package creation API, including authenticated owner discovery, commit attribution, resumable setup, repository configuration, and optional Codecov setup.
- Add an interactive command-line UI with numbered owner/template/visibility choices, package-name availability suggestions, explicit examples and defaults, and final confirmation.
- Consolidate template discovery and rendering behavior, and document and test the local workflow.

## User impact

Users can create or resume Julia package repositories interactively, select only eligible owners, avoid conflicting repository names, optionally configure Codecov, and create commits attributed to the authenticated GitHub user.

The Codecov token is normalized to `String`, and the public API accepts `AbstractString`, which also fixes the reported `SubString{String}` dispatch failure.

## Validation

- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
- `julia --project=docs --startup-file=no -e 'include("docs/make.jl")'`

## Issues

Close #12
Close #13
Close #14
Close #15
Close #16
Close #17
Close #18
Close #19
Close #20
Close #21
Close #24
Close #25
Close #26
Close #27
Close #28

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.